### PR TITLE
Use ledger print command instead of journal parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.venv/
 *.pyc
 __pycache__/
 /db.sqlite3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django>=2.2, <3.0
 pandas>=0.24
-fido2
+fido2>=0.9.3, <1.0

--- a/utils/ledger_api.py
+++ b/utils/ledger_api.py
@@ -299,24 +299,23 @@ class Journal:
             }
 
         entry = []
-        with open(self.path, 'r') as ledger_file:
-            for line in map(str.rstrip, ledger_file):
-                if not entry:
-                    # Skipping the empty space and non-entries between entries.
-                    if re.match(r'{} '.format(date_regexp), line):
-                        # A beginning of a next entry.
-                        entry.append(line)
+        for line in self._call("print"):
+            if not entry:
+                # Skipping the empty space and non-entries between entries.
+                if re.match(r'{} '.format(date_regexp), line):
+                    # A beginning of a next entry.
+                    entry.append(line)
+            else:
+                # In the middle of parsing an entry.
+                if line:
+                    # Let's parse some more of it.
+                    entry.append(line)
                 else:
-                    # In the middle of parsing an entry.
-                    if line:
-                        # Let's parse some more of it.
-                        entry.append(line)
-                    else:
-                        # End of an entry.
-                        yield prepare_entry(entry)
-                        entry = []
-            if entry:
-                yield prepare_entry(entry)
+                    # End of an entry.
+                    yield prepare_entry(entry)
+                    entry = []
+        if entry:
+            yield prepare_entry(entry)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
These changes allow to use extended ledger syntax in the base journal, thus indirectly implementing #1. For example, the base journal may look like
```
include bank1.ledger
include bank2.ledger
```
and combined journal will be correctly shown on the web interface
Also, I've pinned the `fido2` package version to the latest available <1.0 (0.9.3), as it seems that version >=1.0 has changed API and thus incompartible with the current ledger-web codebase.